### PR TITLE
support named arguments in commands by replacing $n with extra value

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Say, we have the following aliases.
 
 ```
 foo=goo
-ring=goo --name=$1
+ring=goo --name=$1 --message=$2
 wow=super useful
 ```
 
@@ -55,7 +55,7 @@ wow=super useful
 
 `hubot foo 1 2 3` => `hubot goo 1 2 3`
 
-`hubot ring john` => `hubot goo --name=john`
+`hubot ring john hello` => `hubot goo --name=john --message=hello`
 
 `hubot ring john test` => `hubot goo --name=john test`
 
@@ -87,4 +87,3 @@ Copyright (c) 2014 Daisuke Taniwaki. See [LICENSE](LICENSE) for details.
 [deps-link]:   https://david-dm.org/dtaniwaki/hubot-alias
 [cov-image]:   https://coveralls.io/repos/dtaniwaki/hubot-alias/badge.png
 [cov-link]:    https://coveralls.io/r/dtaniwaki/hubot-alias
-

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ wow=super useful
 
 `hubot ring john hello` => `hubot goo --name=john --message=hello`
 
-`hubot ring john test` => `hubot goo --name=john test`
+`hubot ring john hello test` => `hubot goo --name=john --message=hello test`
 
 `hubot bar foo` => `hubot bar foo`
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Say, we have the following aliases.
 
 ```
 foo=goo
+ring=goo --name=$1
 wow=super useful
 ```
 
@@ -53,6 +54,10 @@ wow=super useful
 `hubot foos` => `hubot foos`
 
 `hubot foo 1 2 3` => `hubot goo 1 2 3`
+
+`hubot ring john` => `hubot goo --name=john`
+
+`hubot ring john test` => `hubot goo --name=john test`
 
 `hubot bar foo` => `hubot bar foo`
 

--- a/src/scripts/alias.coffee
+++ b/src/scripts/alias.coffee
@@ -13,6 +13,15 @@
 
 ALIAS_TABLE_KEY = 'hubot-alias-table'
 
+loadArgumentsInAction = (args, action) ->
+  argItems = args.trim().split(' ')
+
+  for val, i in argItems
+	  if action.indexOf('$'+(i+1)) > -1 then action = action.replace('$'+(i+1), val) else action += " #{val}"
+
+  action.trim()
+
+
 module.exports = (robot) ->
   receiveOrg = robot.receive
   robot.receive = (msg)->
@@ -23,9 +32,13 @@ module.exports = (robot) ->
       sp = RegExp.$2
       action = RegExp.$3
       rest = RegExp.$4
-      msg.text = "#{name}#{sp}#{table[action] || action}#{rest}" if action != 'alias'
-    console.log "Replace \"#{orgText}\" as \"#{msg.text}\"" if orgText != msg.text
 
+      if action != 'alias'
+        action = table[action] or action
+        msg.text = "#{name}#{sp}"
+        msg.text += loadArgumentsInAction(rest, action)
+
+    console.log "Replace \"#{orgText}\" as \"#{msg.text}\"" if orgText != msg.text
     receiveOrg.bind(robot)(msg)
 
   robot.respond /alias(.*)$/i, (msg)->

--- a/test/alias_test.coffee
+++ b/test/alias_test.coffee
@@ -68,7 +68,7 @@ describe 'alias', ->
 
   describe 'receive hook', ->
     beforeEach ->
-      robot.brain.get = -> {foo: 'goo', wow: 'super useful', alias: 'hacked', params: 'goo --name=$1'}
+      robot.brain.get = -> {foo: 'goo', wow: 'super useful', alias: 'hacked', params: 'goo --name=$1 --message=$2'}
 
       # respond to all messages to check them
       robot.respond /(.*)$/i, (msg)->
@@ -78,7 +78,7 @@ describe 'alias', ->
     it 'replaces alias string', (done)->
       sharedExample done, 'hubot foo', 'goo'
     it 'replaces alias string with params', (done)->
-      sharedExample done, 'hubot params john', 'goo --name=john'
+      sharedExample done, 'hubot params john hello', 'goo --name=john --message=hello'
     it 'does not replace front-matching string', (done)->
       sharedExample done, 'hubot foos', 'foos'
     it 'does not replace anything', (done)->
@@ -162,5 +162,3 @@ describe 'alias', ->
           done e
       adapter.receive new TextMessage(user, "hubot alias bar=")
       expect(@brainSetSpy).to.have.been.calledWith sinon.match.string, {foo: 'goo'}
-
-

--- a/test/alias_test.coffee
+++ b/test/alias_test.coffee
@@ -68,7 +68,7 @@ describe 'alias', ->
 
   describe 'receive hook', ->
     beforeEach ->
-      robot.brain.get = -> {foo: 'goo', wow: 'super useful', alias: 'hacked'}
+      robot.brain.get = -> {foo: 'goo', wow: 'super useful', alias: 'hacked', params: 'goo --name=$1'}
 
       # respond to all messages to check them
       robot.respond /(.*)$/i, (msg)->
@@ -77,6 +77,8 @@ describe 'alias', ->
 
     it 'replaces alias string', (done)->
       sharedExample done, 'hubot foo', 'goo'
+    it 'replaces alias string with params', (done)->
+      sharedExample done, 'hubot params john', 'goo --name=john'
     it 'does not replace front-matching string', (done)->
       sharedExample done, 'hubot foos', 'foos'
     it 'does not replace anything', (done)->

--- a/test/alias_test.coffee
+++ b/test/alias_test.coffee
@@ -42,7 +42,7 @@ describe 'alias', ->
 
   afterEach ->
     do robot.shutdown
-    do robot.server.close
+    do robot.server.close if robot.server
     process.removeAllListeners 'uncaughtException'
 
   sharedExample = (done, src, dst)->


### PR DESCRIPTION
Example:
ring=goo --name=$1
hubot ring john` => `hubot goo --name=john

Extra arguments will just be appended:
hubot ring john test` => `hubot goo --name=john test