### PR TITLE
make alias listen to case insensitive commands

### DIFF
--- a/src/scripts/alias.coffee
+++ b/src/scripts/alias.coffee
@@ -29,7 +29,7 @@ module.exports = (robot) ->
   robot.receive = (msg)->
     table = robot.brain.get(ALIAS_TABLE_KEY) || {}
     orgText = msg.text?.trim()
-    if new RegExp("(^[@]?(?:#{robot.name}|#{robot.alias})[:,]?)(\\s+)([^\\s]*)(.*)$").test orgText
+    if new RegExp("(^[@]?(?:#{robot.name}|#{robot.alias})[:,]?)(\\s+)([^\\s]*)(.*)$", "i").test orgText
       name = RegExp.$1
       sp = RegExp.$2
       action = RegExp.$3


### PR DESCRIPTION
I am using slack on phone, and it Capitalises the first letter of the sentence, which in HuBot's case is the bot's name. I need it to respond to both case sensitive and insensitive.

For example, my bot is named Dave. In slack, it responds to _dave myAlias_ but not to `Dave myAlias`, but, it responds to a simple _Dave help_ or _dave help_.
