### PR TITLE
Temporary solution for spaces

### DIFF
--- a/src/scripts/alias.coffee
+++ b/src/scripts/alias.coffee
@@ -36,7 +36,7 @@ module.exports = (robot) ->
       rest = RegExp.$4
 
       if action != 'alias'
-        action = table[action] or action
+        action = table[action] or table[action+rest] or action
         msg.text = "#{name}#{sp}"
         msg.text += loadArgumentsInAction(rest, action)
 
@@ -55,7 +55,7 @@ module.exports = (robot) ->
         s.push "#{k} : #{v}"
       msg.send "Here you go.\n#{s.join("\n")}"
     else
-      match = text.match /([^\s=]*)=(.*)?$/
+      match = text.match /([^=]*)=(.*)?$/
       alias = match[1]
       action = match[2]
       if action?


### PR DESCRIPTION
At least this way it triggers when only alias was used, e.g.
> bot alias do something=something
> bot do something

will work
> bot do something stupid

won't

I guess the right solution would be to pass through all the aliases and replace the original string, not sure what to do with the arguments.
This would be a better approach IMO:
> bot alias do=whatever $server
> bot do server=g.com
