### PR TITLE
fixed placeholder replacement

### DIFF
--- a/src/scripts/alias.coffee
+++ b/src/scripts/alias.coffee
@@ -20,8 +20,8 @@ loadArgumentsInAction = (args, action) ->
 
     for val, i in argItems
       if action.indexOf('$'+(i+1)) > -1 then action = action.replace('$'+(i+1), val) else action += " #{val}"
-  if action.indexOf('alias') != 0
-    action = action.replace(/\$\d+/g, "")
+
+  action = action.replace(/\$\d+/g, "")
   action.trim()
 
 
@@ -35,7 +35,7 @@ module.exports = (robot) ->
       sp = RegExp.$2
       action = RegExp.$3
 
-      if action && action != 'alias'
+      if action && action.indexOf('alias') != 0
         rest = ''
         for k in Object.keys(table).sort().reverse()
           v = table[k]

--- a/src/scripts/alias.coffee
+++ b/src/scripts/alias.coffee
@@ -20,7 +20,8 @@ loadArgumentsInAction = (args, action) ->
 
     for val, i in argItems
       if action.indexOf('$'+(i+1)) > -1 then action = action.replace('$'+(i+1), val) else action += " #{val}"
-  action = action.replace(/\$\d+/g, "")
+  if action.indexOf('alias') != 0
+    action = action.replace(/\$\d+/g, "")
   action.trim()
 
 

--- a/test/alias_test.coffee
+++ b/test/alias_test.coffee
@@ -93,7 +93,7 @@ describe 'alias', ->
 
     context 'with placeholders in an alias action', ->
       it 'does not replace placeholders', (done)->
-        sharedExample done, 'hubot alias command=something=$1', 'alias command=something=$1'
+        sharedExample done, 'hubot alias command=something=$1 other=$2', 'alias command=something=$1 other=$2'
         
     context 'with reverse order placeholders', ->
       it 'replaces alias string', (done)->

--- a/test/alias_test.coffee
+++ b/test/alias_test.coffee
@@ -47,6 +47,7 @@ describe 'alias', ->
 
   sharedExample = (done, src, dst)->
     adapter.on "send", (envelope, strings)->
+      return if strings[0].indexOf('I made an alias') == 0
       try
         expect(strings).to.have.length(1)
         expect(strings[0]).to.equal dst
@@ -90,6 +91,10 @@ describe 'alias', ->
       it 'appends unused string', (done)->
         sharedExample done, 'hubot params john hello hey', 'goo --name=john --message=hello hey'
 
+    context 'with placeholders in an alias action', ->
+      it 'does not replace placeholders', (done)->
+        sharedExample done, 'hubot alias command=something=$1', 'alias command=something=$1'
+        
     context 'with reverse order placeholders', ->
       it 'replaces alias string', (done)->
         sharedExample done, 'hubot reverse_params john hello hey', 'goo --name=hey --message=john hello'


### PR DESCRIPTION
Fix for #12 

Placeholders e.g. "$1" were being replaced by that line before added as an alias, so

`alias something=blah x=$1`

was being saved as

`alias something=blah x=`

Now we only strip out unused placeholders if the action doesn't start with "alias"